### PR TITLE
Enabled external multifeed to be provided through opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Create a new kappa-core database.
   is used with the string as the filename.
 - Valid `opts` include:
   - `valueEncoding`: a string describing how the data will be encoded.
+  - `multifeed`: A preconfigured instance of [noffle/multifeed](https://github.com/noffle/multifeed)
 
 ### var feed = core.feed(name, cb)
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ module.exports = Kappa
 
 function Kappa (storage, opts) {
   if (!(this instanceof Kappa)) return new Kappa(storage, opts)
+  if (!opts) opts = {}
 
-  this._logs = multifeed(hypercore, storage, opts)
+  this._logs = opts.multifeed || multifeed(hypercore, storage, opts)
   this._indexes = {}
 
   this.api = {}


### PR DESCRIPTION
A small patch that enables kappa-core to use an external multifeed if provided.

I patched it because in my case I'm using a custom hypercore factory, and some experimental middleware, so it made more sense to expose kappa-core's multifeed as an option compared to monkey-patching during initialization.
https://github.com/telamon/hypervault/blob/master/index.js#L73
