### PR TITLE
fix: .feed would only return a writer

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ Kappa.prototype.resume = function (viewNames) {
 Kappa.prototype.feed = function (name, cb) {
   var feed = this._logs.feed(name)
   if (feed) return cb(null, feed)
-  if (!feed) this._logs.writer(name, cb)
+  else this._logs.writer(name, cb)
 }
 
 Kappa.prototype.replicate = function (opts) {

--- a/index.js
+++ b/index.js
@@ -115,7 +115,9 @@ Kappa.prototype.resume = function (viewNames) {
 }
 
 Kappa.prototype.feed = function (name, cb) {
-  this._logs.writer(name, cb)
+  var feed = this._logs.feed(name)
+  if (feed) return cb(null, feed)
+  if (!feed) this._logs.writer(name, cb)
 }
 
 Kappa.prototype.replicate = function (opts) {


### PR DESCRIPTION
After I replicate, sometimes I want access to one of the other feeds without necessarily making it a writer. This uses the internal `multifeed` api to make sure it's getting the correct feed if that feed already exists.

I'm relying on this for kappa-core [multiwriter hyperdrive](karissa/peerfs)
